### PR TITLE
Removed dead Sepolia faucet

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -57,7 +57,6 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [QuickNode Sepolia Faucet](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW faucet](https://sepolia-faucet.pk910.de/)
-- [Sepolia faucet](https://faucet.sepolia.dev/)
 - [FaucETH](https://fauceth.komputing.org)
 - [Coinbase Wallet Faucet | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)


### PR DESCRIPTION
Removed Sepolia faucet from Faucet list because it's down: 
https://faucet.sepolia.dev/

![Screenshot 2023-08-24 at 01 09 37](https://github.com/blazingrome/ethereum-org-website/assets/136898739/c3775b3b-bf35-428f-a105-df32da70b3e1)
